### PR TITLE
systemd: use sd_notify for watchdog

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-LDFLAGS = -lwiringPi -lmosquitto -lpthread
+LDFLAGS = -lwiringPi -lmosquitto -lsystemd -lpthread
 
 #.PHONY: all clean
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Requires mosquitto runtime and development libraries (websockets not used)
 	> sudo apt-get update
 	> sudo apt-get upgrade
 	> sudo apt-get install mosquitto
-	> sudo apt-get install libmosquitto-dev
+	> sudo apt-get install libmosquitto-dev libsystemd-dev
 	> sudo apt-get install mosquitto-clients
 
 Ensuring that the mosquitto MQTT broker is functioning properly is beyond the scope of this document.  There are plenty of other resources, but do make sure it's working before proceeding.

--- a/vedirect_to_mqtt.c
+++ b/vedirect_to_mqtt.c
@@ -8,6 +8,7 @@
 #include <errno.h>
 #include <ctype.h>
 #include <pthread.h>
+#include <systemd/sd-daemon.h>
 
 #include <mosquitto.h>
 #include <wiringSerial.h>
@@ -566,6 +567,7 @@ int main ()
         }
 
         sleep(1);
+        sd_notify(0, "WATCHDOG=1");
     }
 
     printf("Waiting for threads to terminate...\r\n");


### PR DESCRIPTION
The systemd service file uses WatchdogSec, but never triggered a sd_notify.